### PR TITLE
Change to workbench moderation to allow entity code

### DIFF
--- a/oa_workbench.make
+++ b/oa_workbench.make
@@ -14,6 +14,7 @@ projects[workbench_moderation][download][branch] = 7.x-1.x
 projects[workbench_moderation][patch][1285090] = http://drupal.org/files/playnicewithpanels-1285090-22.patch
 projects[workbench_moderation][patch][2175891] = http://drupal.org/files/issues/workbench_moderation-hooks-2175891-3.patch
 projects[workbench_moderation][patch][2194519] = http://drupal.org/files/issues/workbench_hook_proceed_2194519_2.patch
+projects[workbench_moderation][patch][2174343] = http://drupal.org/files/issues/workbench_moderation_2174343_v4.patch
 
 ; TODO: Update to official Drupal.org Git repo and select a specific version.
 projects[workbench_moderation_profile][type] = module
@@ -21,5 +22,5 @@ projects[workbench_moderation_profile][subdir] = contrib
 projects[workbench_moderation_profile][download][url] = http://git.drupal.org/sandbox/srjosh/2172925.git
 projects[workbench_moderation_profile][download][type] = git
 ;projects[workbench_moderation_profile][download][revision] = XXXXXXX
-projects[workbench_moderation_profile][download][branch] = 7.x-1.x
+projects[workbench_moderation_profile][download][branch] = 7.x-1.x-no-transition-entity
 


### PR DESCRIPTION
 to happen in workbench_moderation.

Patch updates workbench_moderation to include that code; change in branch of workbench_moderation_profile takes it out of that module.
